### PR TITLE
Add C++20 project skeleton for Hybrid A* frontiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/build/
+CMakeCache.txt
+CMakeFiles/
+*.o
+*.obj
+*.exe
+*.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.16)
+project(HybridAStarFrontiers LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(BUILD_TESTS "Build tests" ON)
+option(BUILD_BENCHMARKS "Build benchmarks" ON)
+
+add_library(frontier INTERFACE)
+target_include_directories(frontier INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_compile_features(frontier INTERFACE cxx_std_20)
+
+add_executable(hybrid-a-star-frontiers src/main.cpp)
+target_link_libraries(hybrid-a-star-frontiers PRIVATE frontier)
+target_compile_options(hybrid-a-star-frontiers PRIVATE -Wall -Wextra -Wpedantic -Werror)
+
+if(BUILD_TESTS)
+  enable_testing()
+  add_executable(test_minimal tests/test_minimal.cpp)
+  target_link_libraries(test_minimal PRIVATE frontier)
+  target_compile_options(test_minimal PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  add_test(NAME MinimalTest COMMAND test_minimal)
+endif()
+
+if(BUILD_BENCHMARKS)
+  add_executable(frontier_bench benchmarks/frontier_bench.cpp)
+  target_link_libraries(frontier_bench PRIVATE frontier)
+  target_compile_options(frontier_bench PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Fast-Hybrid-A-star-algorithm
+# hybrid-a-star-frontiers
+
+Minimal C++20 skeleton for experimenting with Hybrid A* frontiers.
+Built with CMake.
+
+## Build
+
+```bash
+cmake -S . -B build
+cmake --build build
+```

--- a/benchmarks/frontier_bench.cpp
+++ b/benchmarks/frontier_bench.cpp
@@ -1,0 +1,15 @@
+#include "frontier.hpp"
+#include <chrono>
+#include <iostream>
+
+using namespace hybrid_a_star::frontier;
+
+int main() {
+    Frontier f;
+    auto start = std::chrono::steady_clock::now();
+    f.touch();
+    auto end = std::chrono::steady_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    std::cout << "Frontier bench elapsed: " << elapsed.count() << "s\n";
+    return 0;
+}

--- a/configs/planner_defaults.yaml
+++ b/configs/planner_defaults.yaml
@@ -1,0 +1,3 @@
+planner:
+  max_iterations: 1000
+  step_size: 0.5

--- a/include/frontier.hpp
+++ b/include/frontier.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace hybrid_a_star::frontier {
+
+class Frontier {
+public:
+    void touch() const noexcept {}
+};
+
+} // namespace hybrid_a_star::frontier

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hybrid A* Frontiers - prototype\n";
+    return 0;
+}

--- a/tests/mini_test.h
+++ b/tests/mini_test.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <functional>
+#include <iostream>
+#include <vector>
+
+namespace mini_test {
+using test_func = std::function<void()>;
+
+inline std::vector<test_func>& registry() {
+    static std::vector<test_func> tests;
+    return tests;
+}
+
+struct registrar {
+    registrar(test_func fn) { registry().push_back(fn); }
+};
+
+#define TEST(name) \
+    void name(); \
+    static ::mini_test::registrar registrar_##name(name); \
+    void name()
+
+inline int failures = 0;
+
+#define EXPECT_TRUE(cond)                                                       \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            std::cerr << __FILE__ << ":" << __LINE__                            \
+                      << " EXPECT_TRUE(" #cond ") failed\n";                    \
+            ++::mini_test::failures;                                            \
+        }                                                                       \
+    } while (0)
+
+#define EXPECT_EQ(a, b)                                                         \
+    do {                                                                        \
+        if (!((a) == (b))) {                                                    \
+            std::cerr << __FILE__ << ":" << __LINE__                            \
+                      << " EXPECT_EQ(" #a ", " #b ") failed: " << (a)           \
+                      << " != " << (b) << "\n";                                 \
+            ++::mini_test::failures;                                            \
+        }                                                                       \
+    } while (0)
+
+} // namespace mini_test
+
+int main() {
+    for (auto& t : mini_test::registry()) t();
+    if (mini_test::failures) {
+        std::cerr << mini_test::failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All tests passed\n";
+    return 0;
+}

--- a/tests/test_minimal.cpp
+++ b/tests/test_minimal.cpp
@@ -1,0 +1,8 @@
+#include "mini_test.h"
+
+using namespace mini_test;
+
+TEST(BasicAssertions) {
+    EXPECT_TRUE(true);
+    EXPECT_EQ(1, 1);
+}


### PR DESCRIPTION
## Summary
- bootstrap HybridAStarFrontiers CMake project with C++20 and warning flags
- add minimal Frontier class, example benchmark, and config defaults
- include simple header-only test framework with a sample test

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ab363b6fb483279e4b9cf4fd794195