### PR TITLE
Implement BucketHeap frontier and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ if(BUILD_TESTS)
   target_link_libraries(test_minimal PRIVATE frontier)
   target_compile_options(test_minimal PRIVATE -Wall -Wextra -Wpedantic -Werror)
   add_test(NAME MinimalTest COMMAND test_minimal)
+
+  add_executable(test_bucket_heap tests/test_bucket_heap.cpp)
+  target_link_libraries(test_bucket_heap PRIVATE frontier)
+  target_compile_options(test_bucket_heap PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  add_test(NAME BucketHeapTest COMMAND test_bucket_heap)
 endif()
 
 if(BUILD_BENCHMARKS)

--- a/include/bucket_heap.hpp
+++ b/include/bucket_heap.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "frontier.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <deque>
+#include <limits>
+#include <vector>
+
+namespace hybrid_a_star::frontier {
+
+/**
+ * @brief Ring-of-buckets frontier for bounded-suboptimal search (e.g. Weighted A*).
+ *
+ * The container discretises the f-cost space into @p K buckets of width
+ * @p delta and stores entries in the corresponding bucket.  Buckets are scanned
+ * in a cyclic manner, providing \f$O(1)\f$ amortised insertion while
+ * maintaining an approximate ordering on the f-cost.  The structure does *not*
+ * provide a strict total order; for exact optimality use WindowedFQueue or a
+ * binary heap instead.  For bounded-suboptimal Weighted A* choose @p delta
+ * relative to the minimum edge cost and the heuristic weight.
+ *
+ * @tparam Entry payload type representing a search node.
+ */
+template <typename Entry>
+class BucketHeap : public IFrontier<Entry> {
+public:
+    /**
+     * @brief Construct a bucket heap.
+     *
+     * @param delta Width of each bucket.
+     * @param K Number of buckets in the ring.
+     */
+    BucketHeap(double delta, std::size_t K)
+        : delta_(delta),
+          K_(K),
+          buckets_(K),
+          sz_(0),
+          min_idx_(0),
+          min_f_(std::numeric_limits<double>::infinity()),
+          seq_(0) {}
+
+    void push(const Entry& e, double f) override {
+        const std::size_t idx = bucket_index(f);
+        buckets_[idx].push_back({{f, e}, seq_++});
+        ++sz_;
+        if (f < min_f_) {
+            min_f_ = f;
+            min_idx_ = idx;
+        }
+    }
+
+    std::optional<Entry> pop_min() override {
+        if (sz_ == 0) return std::nullopt;
+
+        for (std::size_t off = 0; off < K_; ++off) {
+            const std::size_t idx = (min_idx_ + off) % K_;
+            auto& bucket = buckets_[idx];
+            if (!bucket.empty()) {
+                std::size_t best = 0;
+                double best_f = bucket[0].item.f;
+                std::size_t best_seq = bucket[0].seq;
+                for (std::size_t i = 1; i < bucket.size(); ++i) {
+                    const auto& cand = bucket[i];
+                    if (cand.item.f < best_f ||
+                        (cand.item.f == best_f && cand.seq < best_seq)) {
+                        best = i;
+                        best_f = cand.item.f;
+                        best_seq = cand.seq;
+                    }
+                }
+
+                FrontierItem<Entry> fi = bucket[best].item;
+                bucket.erase(bucket.begin() + static_cast<long long>(best));
+                --sz_;
+                min_idx_ = idx;
+                min_f_ = fi.f;
+                return fi.payload;
+            }
+        }
+
+        // Inconsistent size accounting; reset.
+        sz_ = 0;
+        min_f_ = std::numeric_limits<double>::infinity();
+        return std::nullopt;
+    }
+
+    [[nodiscard]] bool empty() const override { return sz_ == 0; }
+
+    [[nodiscard]] std::size_t size() const override { return sz_; }
+
+private:
+    struct Node {
+        FrontierItem<Entry> item;
+        std::size_t seq;
+    };
+
+    [[nodiscard]] std::size_t bucket_index(double f) const {
+        long long q = static_cast<long long>(std::floor(f / delta_));
+        long long m = static_cast<long long>(K_);
+        long long r = q % m;
+        if (r < 0) r += m;
+        return static_cast<std::size_t>(r);
+    }
+
+    double delta_;
+    std::size_t K_;
+    std::vector<std::deque<Node>> buckets_;
+    std::size_t sz_;
+    std::size_t min_idx_;
+    double min_f_;
+    std::size_t seq_;
+};
+
+} // namespace hybrid_a_star::frontier
+

--- a/include/frontier.hpp
+++ b/include/frontier.hpp
@@ -8,7 +8,7 @@
 namespace hybrid_a_star::frontier {
 
 /**
- * @brief Interface for A*/Hybrid A* frontier containers.
+ * @brief Interface for A* or Hybrid A* frontier containers.
  *
  * The frontier stores candidate nodes ordered by their estimated total cost
  * \f$f\f$.  Stale entries created by the lack of decrease-key support must be

--- a/tests/test_bucket_heap.cpp
+++ b/tests/test_bucket_heap.cpp
@@ -1,0 +1,47 @@
+#include "mini_test.h"
+
+#include "bucket_heap.hpp"
+
+using namespace hybrid_a_star::frontier;
+using namespace mini_test;
+
+TEST(BucketHeapOrder) {
+    BucketHeap<int> bh(1.0, 8);
+    bh.push(1, 3.0);
+    bh.push(2, 1.0);
+    bh.push(3, 2.0);
+
+    auto a = bh.pop_min();
+    auto b = bh.pop_min();
+    auto c = bh.pop_min();
+
+    EXPECT_TRUE(a.has_value());
+    EXPECT_TRUE(b.has_value());
+    EXPECT_TRUE(c.has_value());
+    EXPECT_EQ(a.value(), 2);
+    EXPECT_EQ(b.value(), 3);
+    EXPECT_EQ(c.value(), 1);
+    EXPECT_TRUE(bh.empty());
+}
+
+TEST(BucketHeapTie) {
+    BucketHeap<int> bh(1.0, 4);
+    bh.push(1, 1.0);
+    bh.push(2, 1.0);
+    auto a = bh.pop_min();
+    auto b = bh.pop_min();
+    EXPECT_TRUE(a.has_value());
+    EXPECT_TRUE(b.has_value());
+    EXPECT_EQ(a.value(), 1);
+    EXPECT_EQ(b.value(), 2);
+}
+
+TEST(BucketHeapNegative) {
+    BucketHeap<int> bh(1.0, 4);
+    bh.push(1, -0.5);
+    bh.push(2, 0.2);
+    auto a = bh.pop_min();
+    EXPECT_TRUE(a.has_value());
+    EXPECT_EQ(a.value(), 1);
+}
+


### PR DESCRIPTION
## Summary
- add `BucketHeap` ring-of-buckets frontier for bounded-suboptimal search
- document Weighted A* usage in `BucketHeap`
- introduce tests for the new frontier

## Testing
- `cmake -S . -B build -DBUILD_BENCHMARKS=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ab567d49e883278f53eb21dd63f474