### PR TITLE
Add planner default configuration

### DIFF
--- a/configs/planner_defaults.yaml
+++ b/configs/planner_defaults.yaml
@@ -1,3 +1,14 @@
-planner:
-  max_iterations: 1000
-  step_size: 0.5
+robot:
+  wheelbase: 2.5
+  kappa_max: 0.2
+  steering_rate_max: 0.5
+heuristic: dubins    # placeholder; currently stub uses euclidean
+step:
+  grid_resolution: 0.1
+  c_min: 1.0
+frontier:
+  type: window
+  delta: 1.0
+  K: 512
+  weight: 1.2
+seeds: [1, 2, 3]


### PR DESCRIPTION
## Summary
- add planner default YAML values for robot, heuristic, step, frontier, and seeds

## Testing
- `cmake -S . -B build`
- `cmake --build build` (fails: frontier_bench.cpp: error: 'Frontier' not declared)
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68ab56bf657083278fdcc9730bdf2568