### PR TITLE
Add CI workflow recommendations

### DIFF
--- a/CI_NOTES.md
+++ b/CI_NOTES.md
@@ -1,0 +1,10 @@
+# CI Notes
+
+Recommended continuous integration checks:
+
+- Build Debug and Release configurations on Linux and macOS with both GCC and Clang.
+- Run all tests and benchmarks.
+- Enable `-DFRONTIER_COLLECT_STATS` in one job to gather frontier statistics.
+- Use AddressSanitizer (`-fsanitize=address,undefined`) for Debug builds.
+- Cache CMake configuration and build artifacts.
+


### PR DESCRIPTION
## Summary
- Document recommended CI checks, including builds, tests, benchmarks, sanitizer, stats, and caching

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(fail: stray '\\' and '@' in `include/frontier.hpp`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56d2e9508327bde3306116b30a35