### PR TITLE
Add hybrid planning integration hooks

### DIFF
--- a/include/planner.hpp
+++ b/include/planner.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+// integration points
+#include "../src/hybrid_hooks.hpp"
+
+namespace hybrid_a_star {
+
+// TODO: planner interface stub
+
+} // namespace hybrid_a_star
+

--- a/src/hybrid_hooks.hpp
+++ b/src/hybrid_hooks.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+namespace hybrid_a_star {
+
+// Basic vehicle state
+struct State {
+    double x{};    ///< position x
+    double y{};    ///< position y
+    double theta{};///< heading angle
+};
+
+// Placeholder for motion primitive description
+struct MotionPrimitive {
+    // TODO: define fields describing motion primitives
+};
+
+// Successor generation from (x, y, theta) using motion primitives
+// std::vector<State> generateSuccessors(const State& current,
+//                                       const std::vector<MotionPrimitive>& primitives);
+
+// Collision checking interface
+// bool isCollisionFree(const State& state);
+
+// Admissible heuristic selection (Euclidean / Dubins / RS)
+// double heuristic(const State& from, const State& to);
+
+// Analytic expansion toggle
+// bool allowAnalyticExpansion();
+
+} // namespace hybrid_a_star
+


### PR DESCRIPTION
## Summary
- add placeholder hooks for hybrid A* integration
- expose hook header from planner.hpp for future planner integration

## Testing
- `cmake -S . -B build -DBUILD_BENCHMARKS=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68ab56f6ea58832796457ba92a79efcf